### PR TITLE
Remove highlights showing before answer

### DIFF
--- a/index.html
+++ b/index.html
@@ -744,10 +744,10 @@ color:#000;
 
 <section class="slide">
 <h2>Example 5</h2>
-<pre><code style="font-size: 65%">&lt;img src="browser-stats.svg" alt="<mark>Browser statistics chart</mark>"
+<pre><code style="font-size: 65%">&lt;img src="browser-stats.svg" alt="Browser statistics chart"
      aria-describedby="browser-stats-desc"&gt;
 &lt;div id="browser-stats-desc"&gt;
-&lt;p&gt;<mark>A pie chart showing the percentage of visitors to Gov.UK using different browsers...</mark>&lt;/p&gt;
+&lt;p&gt;A pie chart showing the percentage of visitors to Gov.UK using different browsers...&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 </section>
 


### PR DESCRIPTION
The example 5 of the accessible name exercise marks the solution one slide too early. This fixes that.