### PR TITLE
Correctly display first bullet point ('Focus')

### DIFF
--- a/exercise5.md
+++ b/exercise5.md
@@ -19,7 +19,7 @@ The disclosure component must:
 
 ## Steps
 1. Write accessibility acceptance criteria based on the following categories:
-    *Focus
+    * Focus
     * Interaction
     * Appearance    
     * State


### PR DESCRIPTION
The focus bullet point is currently displaying as part of the previous line when rendered ("Write accessibility acceptance criteria based on the following categories: *Focus")

This fixes the whitespace for the list item so that is rendered correctly as part of the following list.